### PR TITLE
Adding default n_steps and adding ndim

### DIFF
--- a/gcm_filters/filter.py
+++ b/gcm_filters/filter.py
@@ -189,7 +189,8 @@ class Filter:
           Scales larger than ``pi * filter_scale / 2`` are left as-is. In between is a smooth transition.
     transition_width : float, optional
         Width of the transition region in the "Taper" filter.
-    ndim : Laplacian is applied on a grid of dimension ndim
+    ndim : int, optional
+         Laplacian is applied on a grid of dimension ndim
     grid_type : GridType
         what sort of grid we are dealing with
     grid_vars : dict

--- a/gcm_filters/filter.py
+++ b/gcm_filters/filter.py
@@ -1,12 +1,12 @@
 """Main Filter class."""
 import enum
 
+from dataclasses import dataclass, field
 from typing import Iterable, NamedTuple
 
 import numpy as np
 import xarray as xr
 
-from dataclasses import dataclass, field
 from scipy import interpolate
 
 from .gpu_compat import get_array_module
@@ -68,6 +68,8 @@ def _compute_filter_spec(
 ):
     # First set number of steps if not supplied by user
     if n_steps == 0:
+        if ndim > 2:
+            raise ValueError(f"When ndim > 2, you must set n_steps manually")
         if filter_shape == FilterShape.GAUSSIAN:
             if ndim == 1:
                 n_steps = np.ceil(1.3 * filter_scale / dx_min).astype(int)

--- a/gcm_filters/filter.py
+++ b/gcm_filters/filter.py
@@ -35,10 +35,15 @@ def _taper_target(target_spec: TargetSpec):
             [
                 -1,
                 (2 / target_spec.s_max)
-                * (2*np.pi / (target_spec.transition_width * target_spec.filter_scale))
+                * (
+                    2
+                    * np.pi
+                    / (target_spec.transition_width * target_spec.filter_scale)
+                )
                 ** 2
                 - 1,
-                (2 / target_spec.s_max) * (2*np.pi / target_spec.filter_scale) ** 2 - 1,
+                (2 / target_spec.s_max) * (2 * np.pi / target_spec.filter_scale) ** 2
+                - 1,
                 2,
             ]
         ),
@@ -60,21 +65,27 @@ class FilterSpec(NamedTuple):
 
 
 def _compute_filter_spec(
-    filter_scale, dx_min, n_steps=None, filter_shape, transition_width, ndim, root_tolerance=1e-12
+    filter_scale,
+    dx_min,
+    filter_shape,
+    transition_width,
+    ndim,
+    n_steps=0,
+    root_tolerance=1e-12,
 ):
     # First set number of steps if not supplied by user
-    if n_steps == None:
+    if n_steps == 0:
         if filter_shape == FilterShape.GAUSSIAN:
             if ndim == 1:
-                n_steps = np.ceil(1.3*filter_scale/dx_min).astype(int)
-            else: # ndim==2
-                n_steps = np.ceil(1.8*filter_scale/dx_min).astype(int)
-        else: # Taper
+                n_steps = np.ceil(1.3 * filter_scale / dx_min).astype(int)
+            else:  # ndim==2
+                n_steps = np.ceil(1.8 * filter_scale / dx_min).astype(int)
+        else:  # Taper
             if ndim == 1:
-                n_steps = np.ceil(4.5*filter_scale/dx_min).astype(int)
-            else: # ndim==2
-                n_steps = np.ceil(6.4*filter_scale/dx_min).astype(int)
-    
+                n_steps = np.ceil(4.5 * filter_scale / dx_min).astype(int)
+            else:  # ndim==2
+                n_steps = np.ceil(6.4 * filter_scale / dx_min).astype(int)
+
     # First set up the mass matrix for the Galerkin basis from Shen (SISC95)
     M = (np.pi / 2) * (
         2 * np.eye(n_steps - 1)
@@ -178,7 +189,7 @@ class Filter:
         The smallest grid spacing. Should have same units as ``filter_scale``
     n_steps : int, optional
         Number of total steps in the filter
-        n_steps == None means the number of steps is chosen automatically
+        n_steps == 0 means the number of steps is chosen automatically
     filter_shape : FilterShape
         - ``FilterShape.GAUSSIAN``: The target filter has kernel :math:`e^{-|x/Lf|^2}`
         - ``FilterShape.TAPER``: The target filter has target grid scale Lf. Smaller scales are zeroed out.
@@ -198,10 +209,10 @@ class Filter:
 
     filter_scale: float
     dx_min: float
-    n_steps: int = None
     filter_shape: FilterShape = FilterShape.GAUSSIAN
     transition_width: float = np.pi
     ndim: int = 2
+    n_steps: int = 0
     grid_type: GridType = GridType.CARTESIAN
     grid_vars: dict = field(default_factory=dict, repr=False)
 
@@ -213,10 +224,10 @@ class Filter:
         self.filter_spec = _compute_filter_spec(
             self.filter_scale,
             self.dx_min,
-            self.n_steps,
             self.filter_shape,
             self.transition_width,
             self.ndim,
+            self.n_steps,
         )
 
         # check that we have all the required grid aguments

--- a/gcm_filters/filter.py
+++ b/gcm_filters/filter.py
@@ -60,10 +60,10 @@ class FilterSpec(NamedTuple):
 
 
 def _compute_filter_spec(
-    filter_scale, dx_min, n_steps=-1, filter_shape, transition_width, ndim, root_tolerance=1e-12
+    filter_scale, dx_min, n_steps=None, filter_shape, transition_width, ndim, root_tolerance=1e-12
 ):
     # First set number of steps if not supplied by user
-    if n_steps == -1:
+    if n_steps == None:
         if filter_shape == FilterShape.GAUSSIAN:
             if ndim == 1:
                 n_steps = np.ceil(1.3*filter_scale/dx_min).astype(int)
@@ -178,12 +178,14 @@ class Filter:
         The smallest grid spacing. Should have same units as ``filter_scale``
     n_steps : int, optional
         Number of total steps in the filter
+        n_steps == None means the number of steps is chosen automatically
     filter_shape : FilterShape
         - ``FilterShape.GAUSSIAN``: The target filter has kernel :math:`e^{-|x/Lf|^2}`
         - ``FilterShape.TAPER``: The target filter has target grid scale Lf. Smaller scales are zeroed out.
           Scales larger than ``pi * filter_scale / 2`` are left as-is. In between is a smooth transition.
     transition_width : float, optional
         Width of the transition region in the "Taper" filter.
+    ndim : Laplacian is applied on a grid of dimension ndim
     grid_type : GridType
         what sort of grid we are dealing with
     grid_vars : dict
@@ -196,9 +198,10 @@ class Filter:
 
     filter_scale: float
     dx_min: float
-    n_steps: int = 40
+    n_steps: int = None
     filter_shape: FilterShape = FilterShape.GAUSSIAN
     transition_width: float = np.pi
+    ndim: int = 2
     grid_type: GridType = GridType.CARTESIAN
     grid_vars: dict = field(default_factory=dict, repr=False)
 
@@ -213,6 +216,7 @@ class Filter:
             self.n_steps,
             self.filter_shape,
             self.transition_width,
+            self.ndim,
         )
 
         # check that we have all the required grid aguments

--- a/gcm_filters/filter.py
+++ b/gcm_filters/filter.py
@@ -182,7 +182,7 @@ class Filter:
         The smallest grid spacing. Should have same units as ``filter_scale``
     n_steps : int, optional
         Number of total steps in the filter
-        n_steps == 0 means the number of steps is chosen automatically
+        ``n_steps == 0`` means the number of steps is chosen automatically
     filter_shape : FilterShape
         - ``FilterShape.GAUSSIAN``: The target filter has kernel :math:`e^{-|x/Lf|^2}`
         - ``FilterShape.TAPER``: The target filter has target grid scale Lf. Smaller scales are zeroed out.

--- a/gcm_filters/kernels.py
+++ b/gcm_filters/kernels.py
@@ -4,9 +4,8 @@ Core smoothing routines that operate on 2D arrays.
 import enum
 
 from abc import ABC
-from typing import Any, Dict
-
 from dataclasses import dataclass
+from typing import Any, Dict
 
 from .gpu_compat import ArrayType, get_array_module
 

--- a/gcm_filters/kernels.py
+++ b/gcm_filters/kernels.py
@@ -4,8 +4,9 @@ Core smoothing routines that operate on 2D arrays.
 import enum
 
 from abc import ABC
-from dataclasses import dataclass
 from typing import Any, Dict
+
+from dataclasses import dataclass
 
 from .gpu_compat import ArrayType, get_array_module
 

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -20,30 +20,39 @@ def _check_equal_filter_spec(spec1, spec2):
     "filter_args, expected_filter_spec",
     [
         (
-            dict(filter_scale=10.0, dx_min=1.0, n_steps=4),
+            dict(
+                filter_scale=10.0,
+                dx_min=1.0,
+                filter_shape=FilterShape.GAUSSIAN,
+                transition_width=np.pi,
+                ndim=2,
+                n_steps=4,
+            ),
             FilterSpec(
                 n_lap_steps=4,
-                s_l=[2.36715983, 8.36124821, 15.17931706, 19.7392088],
+                s_l=[2.56046256, 8.47349198, 15.22333438, 19.7392088],
                 n_bih_steps=0,
                 s_b=[],
             ),
         ),
         (
             dict(
-                filter_scale=1.0, dx_min=1.0, n_steps=10, filter_shape=FilterShape.TAPER
+                filter_scale=2.0,
+                dx_min=1.0,
+                filter_shape=FilterShape.TAPER,
+                transition_width=np.pi,
+                ndim=1,
             ),
             FilterSpec(
-                n_lap_steps=6,
-                s_l=[
-                    9.87341331,
-                    12.66526236,
-                    15.23856752,
-                    17.38217753,
-                    18.91899844,
-                    19.7392088,
+                n_lap_steps=1,
+                s_l=[9.8696044],
+                n_bih_steps=4,
+                s_b=[
+                    -0.74638043 - 1.24167777j,
+                    3.06062496 - 3.94612205j,
+                    7.80242999 - 3.18038659j,
+                    9.81491354 - 0.44874939j,
                 ],
-                n_bih_steps=2,
-                s_b=[-1.83974928 - 2.24294603j, 1.21758518 - 8.29775049j],
             ),
         ),
     ],


### PR DESCRIPTION
This PR does a few things:
1. Add in a default for `n_steps` that depends on the coarsening factor (`filter_scale/dx_min`)
2. Add an option to switch between 1d and 2d grids `ndmin`
3. Change the meaning of `filter_scale` in both filter shapes, so that it always corresponds to a boxcar of width `filter_scale`