### PR TITLE
move computation of wet_fac to post_init

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,9 +39,9 @@ repos:
   - id: black
     language_version: python3
 
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.770
-  hooks:
-  - id: mypy
-    exclude: docs/source/conf.py
-    args: [--ignore-missing-imports]
+#- repo: https://github.com/pre-commit/mirrors-mypy
+#  rev: v0.770
+#  hooks:
+#  - id: mypy
+#    exclude: docs/source/conf.py
+#    args: [--ignore-missing-imports]

--- a/gcm_filters/kernels.py
+++ b/gcm_filters/kernels.py
@@ -60,22 +60,24 @@ class CartesianLaplacianWithLandMask(BaseLaplacian):
 
     wet_mask: ArrayType
 
-    def __call__(self, field: ArrayType):
-        np = get_array_module(field)
+    def __post_init__(self):
+        np = get_array_module(self.wet_mask)
 
-        out = field.copy()  # is this necessary?
-        out = np.nan_to_num(field)  # is this necessary?
-        out = self.wet_mask * out
-
-        fac = (
+        self.wet_fac = (
             np.roll(self.wet_mask, -1, axis=-1)
             + np.roll(self.wet_mask, 1, axis=-1)
             + np.roll(self.wet_mask, -1, axis=-2)
             + np.roll(self.wet_mask, 1, axis=-2)
         )
 
+    def __call__(self, field: ArrayType):
+        np = get_array_module(field)
+
+        out = np.nan_to_num(field)  # set all nans to zero
+        out = self.wet_mask * out
+
         out = (
-            -fac * out
+            -self.wet_fac * out
             + np.roll(out, -1, axis=-1)
             + np.roll(out, 1, axis=-1)
             + np.roll(out, -1, axis=-2)


### PR DESCRIPTION
This PR does the following things:

In `CartesianLaplacianWithLandMask`
- move the computation of `fac` (now: `wet_fac`) to pre_init. This factor is independent of the field which the Laplacian is applied to. If we apply the Laplacian many times (as we will for the filtering operation), computing the factor only once will speed things up.
- delete 1 unneccesary line: `out = field.copy()`

Following @rabernat's recommendation in https://github.com/ocean-eddy-cpt/gcm-filters/issues/21#issuecomment-776910274, I also disabled the mypy check.