### PR TITLE
Remove the test modules from coverage report

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,22 @@
+codecov:
+  require_ci_to_pass: no
+  max_report_age: off
+
+comment: false
+
+coverage:
+  precision: 2
+  round: down
+  status:
+    project:
+      default:
+        target: 95
+        informational: true
+    patch: off
+    changes: off
+
+ignore:
+  - "setup.py"
+  - "tests/*"
+  - "gcm-filters/__init__.py"
+  - "gcm-filters/_version.py"

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -178,7 +178,7 @@ tripolar_grids = [gt for gt in GridType if gt.name.startswith("TRIPOLAR")]
 
 
 def test_for_antarctica(grid_type_field_and_extra_kwargs):
-    """This test checks that we get an error if southernmost row of wet_mask has entry not equal to zero. """
+    """This test checks that we get an error if southernmost row of wet_mask has entry not equal to zero."""
     grid_type, _, extra_kwargs = grid_type_field_and_extra_kwargs
 
     if grid_type in tripolar_grids:
@@ -193,7 +193,7 @@ def test_for_antarctica(grid_type_field_and_extra_kwargs):
 
 
 def test_tripolar_exchanges(grid_type_field_and_extra_kwargs):
-    """This test checks that Laplacian exchanges across northern boundary seam line of tripolar grid are correct. """
+    """This test checks that Laplacian exchanges across northern boundary seam line of tripolar grid are correct."""
     grid_type, data, extra_kwargs = grid_type_field_and_extra_kwargs
 
     if grid_type in tripolar_grids:


### PR DESCRIPTION
We should base our coverage only on the actual module, not the test files. 

This also excludes some other python files which should not be tested.