### PR TITLE
Added how to build docs locally

### DIFF
--- a/docs/how_to_contribute.rst
+++ b/docs/how_to_contribute.rst
@@ -67,7 +67,7 @@ How to change the documentation
 
 In order to build the documentation locally you should build and activate the docs environment::
 
-   conda env create -f docs/environment.yml
+   mamba env create -f docs/environment.yml
 
    conda activate gcm-filters-docs
 

--- a/docs/how_to_contribute.rst
+++ b/docs/how_to_contribute.rst
@@ -61,3 +61,24 @@ until all checks pass.
 
 
 Once you got everything to pass, you can stage and commit your changes and push them to the remote github repository.
+
+How to change the documentation
+-------------------------------
+
+In order to build the documentation locally you should build and activate the docs environment::
+
+   conda env create -f docs/environment.yml
+
+   conda activate gcm-filters-docs
+
+Then navigate to the docs folder and build the docs locally with::
+
+   cd docs
+
+   make html
+
+Once that is done you can open the created html files in `docs/_build/index.html` with your webbrowser::
+
+   open _build/index.html
+
+You can then edit and rebuild the docs until you are satisfied and submit a PR as usual.


### PR DESCRIPTION
In #38 @iangrooms asked for instructions on how to build docs locally. I have added instructions here, but ironically I was not able to build them locally. I think there is a problem with my conda env (not resolving to the latest `myst_nb` version). 

@iangrooms could you try to follow these instructions and see if it works for you? Might just be some quirk of my local machine.