### PR TITLE
Fix bug in test_tripolar_exchanges

### DIFF
--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -202,7 +202,7 @@ def test_tripolar_exchanges(grid_type_field_and_extra_kwargs):
 
         delta = np.zeros_like(data)
         nx = np.shape(delta)[1]
-        random_loc = np.random.randint(0, nx)
+        random_loc = np.random.randint(1, nx // 2 - 2)
         delta[-1, random_loc] = 1  # deploy mass at northern boundary
 
         diffused = laplacian(delta)


### PR DESCRIPTION
### Issue
While writing new tests for `gcm-filters` I stumbled upon a similar issue as in https://github.com/ocean-eddy-cpt/gcm-filters/issues/58, but this time caused by the `test_tripolar_exchanges` test.  The issue was a similar one as before: the index range for generating the random delta function was slightly too large (and in this particular case the generated random number landed in a bad spot).

### Solution
The test checks for isotropic diffusion across the northern tripole seam. Diffusion is only isotropic if you stay away from the boundaries and the pivot point (in the middle). So I shortened the column index range for generating the random delta function from `[0, nx)` to `[1, nx // 2 - 2)` to be on the safe side.