### PR TITLE
Adjust coverage settings

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,22 @@
+codecov:
+   require_ci_to_pass: no
+   max_report_age: off
+
+ comment: false
+
+ coverage:
+   precision: 2
+   round: down
+   status:
+     project:
+       default:
+         target: 95
+         informational: true
+     patch: off
+     changes: off
+
+ ignore:
+   - "setup.py"
+   - "tests/*"
+   - "gcm-filters/__init__.py"
+   - "gcm-filters/_version.py"

--- a/codecov.yml
+++ b/codecov.yml
@@ -17,6 +17,6 @@ codecov:
 
  ignore:
    - "setup.py"
-   - "tests/*"
-   - "gcm-filters/__init__.py"
-   - "gcm-filters/_version.py"
+   - "tests"
+   - "**/__init__.py"
+   - "**/_version.py"


### PR DESCRIPTION
We should base our coverage only on the actual module, not the test files.

This also excludes some other python files which should not be tested.

This is picking up #57