### PR TITLE
Verification tests fixes

### DIFF
--- a/gcm_filters/kernels.py
+++ b/gcm_filters/kernels.py
@@ -360,6 +360,21 @@ class POPTripolarLaplacianTpoint(BaseScalarLaplacian):
         if self.wet_mask[..., 0, :].any():
             raise AssertionError("Wet mask requires zeros in southernmost row")
 
+        # check that northern edge grid data folds onto itself
+        nx = np.shape(self.dxn)[-1]
+        first_half = self.dxn[..., [-1], : (nx // 2)]
+        second_half = self.dxn[..., [-1], (nx // 2) :]
+        if not np.all(first_half[..., ::-1] == second_half):
+            raise AssertionError(
+                "Northernmost row of dxn does not fold onto itself. This is a requirement for using a tripole boundary condition."
+            )
+        first_half = self.dyn[..., [-1], : (nx // 2)]
+        second_half = self.dyn[..., [-1], (nx // 2) :]
+        if not np.all(first_half[..., ::-1] == second_half):
+            raise AssertionError(
+                "Northernmost row of dyn does not fold onto itself. This is a requirement for using a tripole boundary condition."
+            )
+
         # prepare grid information for northern boundary exchanges
         self.dxe = _prepare_tripolar_exchanges(self.dxe)
         self.dye = _prepare_tripolar_exchanges(self.dye)

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -206,7 +206,7 @@ def grid_type_and_input_ds(request):
 
     if grid_type == GridType.TRIPOLAR_POP_WITH_LAND:
         for name in _grid_kwargs[grid_type]:
-            if (name == "dxn") or (name == "dyn"):
+            if name in ["dxn", "dyn"]:
                 grid_vars[name] = _make_irregular_tripole_grid_data(ny, nx)
 
     return grid_type, da, grid_vars

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -68,7 +68,8 @@ def _make_irregular_grid_data(shape: Tuple[int, int]) -> np.ndarray:
 @pytest.fixture(scope="module", params=scalar_grids)
 def grid_type_field_and_extra_kwargs(request):
     grid_type = request.param
-    shape = (128, 256)
+    ny, nx = 128, 256
+    shape = (ny, nx)
 
     data = _make_random_data(shape)
 
@@ -81,10 +82,15 @@ def grid_type_field_and_extra_kwargs(request):
         else:
             extra_kwargs[name] = _make_irregular_grid_data(shape)
 
-    # special case for POP
+    # special case for tripole grid
+    # northern edge grid data has to fold on itself
     if grid_type == GridType.TRIPOLAR_POP_WITH_LAND:
-        # is this important? If not, remove special case
-        extra_kwargs["tarea"] = extra_kwargs["dxe"] * extra_kwargs["dye"]
+        # first half of northernmost row
+        half_northern_edge_dxn = extra_kwargs["dxn"][-1, : (nx // 2)]
+        half_northern_edge_dyn = extra_kwargs["dyn"][-1, : (nx // 2)]
+        # has to equal mirrored second half of northernmost row of dxn
+        extra_kwargs["dxn"][-1, (nx // 2) :] = half_northern_edge_dxn[::-1]
+        extra_kwargs["dyn"][-1, (nx // 2) :] = half_northern_edge_dyn[::-1]
 
     return grid_type, data, extra_kwargs
 


### PR DESCRIPTION
Here are some suggestions for how `add-verification-tests` in PR #79 has to be changed in order to get all tests to pass.

### Conservation test
The conservation test for `TRIPOLAR_POP_WITH_LAND` was failing because this Laplacian needs the northernmost row of `dxn` to fold onto itself. Same for `dyn`. This is an inherent property of the tripole grid, without which conservation cannot be satisfied. For example, in the graphic below the x-spacings of the northern grid edge cell of B and E have to be the same.
<img width="615" alt="Screen Shot 2021-08-02 at 3 35 24 PM" src="https://user-images.githubusercontent.com/23617395/127926904-813e798f-1b00-41e6-9543-c7b8c6f6ea5f.png">

I added the symmetry requirement of `dxn` and `dyn` to the fixture that creates the grid data. I also added a test that checks whether the user inputs grid data that satisfies this property.

*Side note for the curious*: This issue has not shown up before because we used identical grid data for `dxn` and `dyn`. If `dxn = dyn`, the flux across the northern edge simplifies to
```
nflux = ((np.roll(data, -1, axis=-2) - data) / self.dyn * self.dxn)
         = (np.roll(data, -1, axis=-2) - data),
```
so we accidentally cancelled out all problems that arose from non-symmetric `dxn` and `dyn` grid data.

### Flux test

@rabernat, I reverted the flux test back to your previous version. The test checks for *isotropic* diffusion, and therefore has to operate on regular grid data. 

Some more background on this test:
The "outlier" values (of 1000, 2000) for `dx`, `dy` are chosen far enough from the delta function so that `Laplacian(delta)` should not feel these outlier values when computing the fluxes, and isotropic diffusion will be satisfied. However, the outlier data is still close enough so that Laplacian(delta) will feel them if `np.roll(dx, -1, axis)` in `kernels.py` is mistakenly coded as `np.roll(dx, +1, axis)` and vice versa. I added these comments to the code, which will hopefully shed some light on how / why this test was designed. Sorry about the confusion!
