### PR TITLE
Updating transition_width and n_steps

### DIFF
--- a/gcm_filters/filter.py
+++ b/gcm_filters/filter.py
@@ -317,6 +317,10 @@ class Filter:
                     "dx_min must be set to 1."
                 )
 
+        # Check if transition_width is <=1
+        if self.transition_width <= 1:
+            raise ValueError(f"Transition width must be > 1.")
+
         # Get default number of steps
         filter_factor = self.filter_scale / self.dx_min
         if self.ndim > 2:

--- a/gcm_filters/filter.py
+++ b/gcm_filters/filter.py
@@ -26,12 +26,12 @@ FilterShape = enum.Enum("FilterShape", ["GAUSSIAN", "TAPER"])
 
 filter_params = {
     FilterShape.GAUSSIAN: {
-        1: {"n_steps_factor": 0.8, "max_filter_factor": 67},
-        2: {"n_steps_factor": 1.1, "max_filter_factor": 77},
+        1: {"offset": 0.8, "factor": 0.0, "exponent": 1, "max_filter_factor": 67},
+        2: {"offset": 1.1, "factor": 0.0, "exponent": 1, "max_filter_factor": 77},
     },
     FilterShape.TAPER: {
-        1: {"n_steps_factor": 2.8, "max_filter_factor": 19},
-        2: {"n_steps_factor": 3.9, "max_filter_factor": 20},
+        1: {"offset": 2.2, "factor": 0.6, "exponent": 2.5, "max_filter_factor": 19},
+        2: {"offset": 3.2, "factor": 0.7, "exponent": 2.7, "max_filter_factor": 20},
     },
 }
 
@@ -282,7 +282,7 @@ class Filter:
         - ``FilterShape.TAPER``: The target filter has target grid scale Lf. Smaller scales are zeroed out.
           Scales larger than ``pi * filter_scale / 2`` are left as-is. In between is a smooth transition.
     transition_width : float, optional
-        Width of the transition region in the "Taper" filter.
+        Width of the transition region in the "Taper" filter. Theoretical minimumm is 1; not recommended.
     ndim : int, optional
          Laplacian is applied on a grid of dimension ndim
     grid_type : GridType
@@ -325,10 +325,13 @@ class Filter:
             else:
                 n_steps_default = self.n_steps  # For ndim>2 we don't have a default
         else:
-            n_steps_default = np.ceil(
-                filter_params[self.filter_shape][self.ndim]["n_steps_factor"]
-                * filter_factor
-            ).astype(int)
+            n_steps_factor = filter_params[self.filter_shape][self.ndim][
+                "offset"
+            ] + filter_params[self.filter_shape][self.ndim]["factor"] * (
+                (np.pi / self.transition_width)
+                ** filter_params[self.filter_shape][self.ndim]["exponent"]
+            )
+            n_steps_default = np.ceil(n_steps_factor * filter_factor).astype(int)
 
         # Set n_steps if needed and issue n_step warning, if needed
         if self.n_steps < 3:

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -329,7 +329,12 @@ def test_diffusion_filter(grid_type_and_input_ds, filter_args):
             )
 
     bad_filter_args = copy.deepcopy(filter_args)
+    # check that we get an error when transition_width <= 1
+    bad_filter_args["transition_width"] = 1
+    with pytest.raises(ValueError, match=r"Transition width .*"):
+        filter = Filter(grid_type=grid_type, grid_vars=grid_vars, **bad_filter_args)
     # check that we get an error if ndim > 2 and n_steps = 0
+    bad_filter_args["transition_width"] = np.pi
     bad_filter_args["ndim"] = 3
     bad_filter_args["n_steps"] = 0
     with pytest.raises(ValueError, match=r"When ndim > 2, you .*"):


### PR DESCRIPTION
This PR does 2 things:

1. Adds a default `n_steps` for general `transition_width`. Previously the default was used for any transition width, but was only accurate for transition widths >= pi.
2. Adds a test that checks if `transition_width > 1`. A user might think that the minimum transition width is 0, which is not true.