### PR TITLE
Link to AMS22 talk in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 ## GCM Filters
 
+[![Tests](https://github.com/ocean-eddy-cpt/gcm-filters/workflows/Tests/badge.svg)](https://github.com/ocean-eddy-cpt/gcm-filters/actions?query=workflow%3ATests)
 [![codecov](https://codecov.io/gh/ocean-eddy-cpt/gcm-filters/branch/master/graph/badge.svg?token=ZKRiulYe68)](https://codecov.io/gh/ocean-eddy-cpt/gcm-filters)
 [![pre-commit](https://github.com/ocean-eddy-cpt/gcm-filters/workflows/pre-commit/badge.svg)](https://github.com/ocean-eddy-cpt/gcm-filters/actions?query=workflow%3Apre-commit)
-[![Tests](https://github.com/ocean-eddy-cpt/gcm-filters/workflows/Tests/badge.svg)](https://github.com/ocean-eddy-cpt/gcm-filters/actions?query=workflow%3ATests)
 [![Documentation Status](https://readthedocs.org/projects/gcm-filters/badge/?version=latest)](https://gcm-filters.readthedocs.io/en/latest/?badge=latest)
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gcm_filters.svg)](https://anaconda.org/conda-forge/gcm_filters)
 [![PyPI version](https://badge.fury.io/py/gcm-filters.svg)](https://badge.fury.io/py/gcm-filters)
+[![Downloads](https://pepy.tech/badge/gcm-filters)](https://pepy.tech/project/gcm-filters)
 [![status](https://joss.theoj.org/papers/bc8ad806627f0d754347686e21f00d40/status.svg)](https://joss.theoj.org/papers/bc8ad806627f0d754347686e21f00d40)
 
 GCM-Filters: Diffusion-based Spatial Filtering of Gridded Data

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,5 +1,5 @@
-API
-===
+API Reference
+=============
 
 Filter Class
 ------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,7 +19,7 @@ GCM Filters: Diffusion-based Spatial Filtering of Gridded Data
    :target: https://badge.fury.io/py/gcm-filters
 
 .. image:: https://pepy.tech/badge/gcm-filters
-   :target: https://pepy.tech/badge/gcm-filters
+   :target: https://pepy.tech/project/gcm-filters
 
 .. image:: https://joss.theoj.org/papers/bc8ad806627f0d754347686e21f00d40/status.svg
    :target: https://joss.theoj.org/papers/bc8ad806627f0d754347686e21f00d40

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,6 +3,9 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+GCM Filters: Diffusion-based Spatial Filtering of Gridded Data
+===============================================================
+
 .. image:: https://github.com/ocean-eddy-cpt/gcm-filters/workflows/Tests/badge.svg
    :target: https://github.com/ocean-eddy-cpt/gcm-filters/actions?query=workflow%3ATests
 
@@ -21,11 +24,7 @@
 .. image:: https://joss.theoj.org/papers/bc8ad806627f0d754347686e21f00d40/status.svg
    :target: https://joss.theoj.org/papers/bc8ad806627f0d754347686e21f00d40
 
-
-
-GCM Filters: Diffusion-based Spatial Filtering of Gridded Data
-===============================================================
-
+|
 **GCM-Filters** is a python package that performs spatial filtering analysis in a flexible and efficient way.
 The GCM-Filters algorithm applies a discrete Laplacian to smooth a field through an iterative process that resembles diffusion (see :doc:`theory` or `Grooms et al., 2021 <https://doi.org/10.1029/2021MS002552>`_).
 The package can be used for either gridded observational data or gridded data that is produced by General Circulation Models (GCMs) of ocean, weather, and climate.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,10 +31,8 @@ The package can be used for either gridded observational data or gridded data th
 Such GCM data come on complex curvilinear grids, whose geometry is respected by the GCM-Filters Laplacians.
 Through integration with `dask <https://dask.org/>`_, GCM-Filters enables parallel, out-of-core filter analysis on both CPUs and GPUs.
 
-`AMS 2022 Talk <https://noraloose.github.io/ams2022-talk/>`_
-
-Contents
---------
+Getting Started
+----------------
 
 .. toctree::
    :maxdepth: 1
@@ -48,13 +46,20 @@ Contents
    examples/example_vector_laplacian
    examples/example_numerical_instability
    examples/example_satellite_observations
+
+References
+----------
+
+.. toctree::
+   :maxdepth: 1
+
+   AMS 2022 Talk <https://noraloose.github.io/ams2022-talk/>
    api
    how_to_contribute
 
 
-
 Indices and tables
-==================
+------------------
 
 * :ref:`genindex`
 * :ref:`modindex`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,6 +3,26 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+.. image:: https://github.com/ocean-eddy-cpt/gcm-filters/workflows/Tests/badge.svg
+   :target: https://github.com/ocean-eddy-cpt/gcm-filters/actions?query=workflow%3ATests
+
+.. image:: https://codecov.io/gh/ocean-eddy-cpt/gcm-filters/branch/master/graph/badge.svg?token=ZKRiulYe68
+   :target: https://codecov.io/gh/ocean-eddy-cpt/gcm-filters
+
+.. image:: https://img.shields.io/conda/vn/conda-forge/gcm_filters.svg
+   :target: https://anaconda.org/conda-forge/gcm_filters
+
+.. image:: https://badge.fury.io/py/gcm-filters.svg
+   :target: https://badge.fury.io/py/gcm-filters
+
+.. image:: https://pepy.tech/badge/gcm-filters
+   :target: https://pepy.tech/badge/gcm-filters
+
+.. image:: https://joss.theoj.org/papers/bc8ad806627f0d754347686e21f00d40/status.svg
+   :target: https://joss.theoj.org/papers/bc8ad806627f0d754347686e21f00d40
+
+
+
 GCM Filters: Diffusion-based Spatial Filtering of Gridded Data
 ===============================================================
 
@@ -11,6 +31,8 @@ The GCM-Filters algorithm applies a discrete Laplacian to smooth a field through
 The package can be used for either gridded observational data or gridded data that is produced by General Circulation Models (GCMs) of ocean, weather, and climate.
 Such GCM data come on complex curvilinear grids, whose geometry is respected by the GCM-Filters Laplacians.
 Through integration with `dask <https://dask.org/>`_, GCM-Filters enables parallel, out-of-core filter analysis on both CPUs and GPUs.
+
+`AMS 2022 Talk <https://noraloose.github.io/ams2022-talk/>`_
 
 Contents
 --------

--- a/paper.md
+++ b/paper.md
@@ -42,6 +42,9 @@ authors:
   - name: Laure Zanna
     orcid: 0000-0002-8472-4828
     affiliation: 3
+  - name: Paige Martin
+    orcid: 0000-0003-3538-633X
+    affiliation: "2, 7"
 affiliations:
   - name: Department of Applied Mathematics, University of Colorado Boulder, Boulder, CO, USA
     index: 1
@@ -55,6 +58,8 @@ affiliations:
     index: 5
   - name: Earth, Ocean and Ecological Sciences, University of Liverpool, UK
     index: 6
+  - name: Australian National University, Canberra, Australia
+    index: 7
 
 date: 1 November 2021
 bibliography: paper.bib

--- a/paper.md
+++ b/paper.md
@@ -18,7 +18,7 @@ authors:
   - name: Julius Busecke
     orcid: 0000-0001-8571-865X
     affiliation: 2
-  - name: Arthur Barthe
+  - name: Arthur Guillaumin
     orcid: 0000-0003-1571-4228
     affiliation: 3
   - name: Elizabeth Yankovsky


### PR DESCRIPTION
I'm giving a talk on GCM-Filters in the Python Symposium in next week's AMS meeting. This PR adds a link to my slides in the documentation. The slides are hosted [here](https://noraloose.github.io/ams2022-talk/#/). Everyone on the JOSS Paper is a co-author on this talk. I may give a slightly shorter (12-min) version of these slides next Tuesday.

cc @rabernat @iangrooms @jbusecke @arthurBarthe @ElizabethYankovsky @gustavo-marques @jakesteinberg @asross @hmkhatri @sdbachman @LaureZanna @paigem

I have also invited Paige as a co-author on the JOSS paper and talk. Paige is working on implementing the B-grid vector Laplacian (#128), and is keen on contributing to GCM-Filters!

This PR also adds some badges to the documentation.