### PR TITLE
Fix python version for tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,6 +33,7 @@ jobs:
           mamba-version: "*"
           channels: conda-forge, defaults
           channel-priority: true
+          python-version: ${{ matrix.python-version }}
           activate-environment: gcm-filters-env
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
       - shell: bash -l {0}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Cache conda

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ flake8-print
 interrogate
 isort
 nbsphinx
-numcodecs==0.10.1
+numcodecs
 pre-commit
 pylint
 pytest


### PR DESCRIPTION
As pointed out correctly by @pbranson [here](https://github.com/zarr-developers/numcodecs/issues/350#issuecomment-1228887635) the CI was actually not testing with the python versions specified (and seems to have defaulted to some newer version). 
This should correct that behavior.